### PR TITLE
Add MinVer package and simplify Github workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     branches:
-      - '*'       
+      - "*"
   release:
     types:
       - published
@@ -24,56 +24,42 @@ jobs:
   create_nuget:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-    - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: nuget
-        if-no-files-found: error
-        retention-days: 7
-        path: ${{ env.NuGetDirectory }}/*.nupkg
-
-  validate_nuget:
-    runs-on: ubuntu-latest
-    needs: [ create_nuget ]
-    steps:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
+      - run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: nuget
-          path: ${{ env.NuGetDirectory }}
+          if-no-files-found: error
+          retention-days: 7
+          path: ${{ env.NuGetDirectory }}/*.nupkg
 
   run_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-    - name: Run tests
-      run: dotnet test --configuration Release
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+      - name: Run tests
+        run: dotnet test --configuration Release
 
   deploy:
-  
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
-    needs: [ validate_nuget, run_test ]
+    needs: [run_test]
     steps:
-    
       - uses: actions/download-artifact@v3
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
-        
+
       - name: Publish NuGet package
         run: |
           foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {

--- a/src/FriendlyDateOnlys/FriendlyDateOnlys.csproj
+++ b/src/FriendlyDateOnlys/FriendlyDateOnlys.csproj
@@ -7,4 +7,11 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="MinVer" Version="4.3.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/src/FriendlyDateTimeOffsets/FriendlyDateTimeOffsets.csproj
+++ b/src/FriendlyDateTimeOffsets/FriendlyDateTimeOffsets.csproj
@@ -7,4 +7,11 @@
         <IsPackable>true</IsPackable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="MinVer" Version="4.3.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/src/FriendlyDateTimes/FriendlyDateTimes.csproj
+++ b/src/FriendlyDateTimes/FriendlyDateTimes.csproj
@@ -7,4 +7,11 @@
         <TargetFrameworks>net8.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="MinVer" Version="4.3.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
MinVer package version 4.3.0 has been added to FriendlyDateTimeOffsets, FriendlyDateTimes, and FriendlyDateOnlys projects. Additionally, the Github workflow, specifically publish.yaml, is simplified by removing the validate_nuget job and directly running tests in the deploy job.